### PR TITLE
Fix negative rating sorting

### DIFF
--- a/utils/formatRaterData.js
+++ b/utils/formatRaterData.js
@@ -46,7 +46,10 @@ module.exports = values => {
         negativeCount
       ];
     })
-    .sort((firstArray, secondArray) => secondArray[1] - firstArray[1])
+    .sort(
+      (firstArray, secondArray) =>
+        (parseInt(secondArray[1], 10) - parseInt(firstArray[1], 10)),
+      )
     .map((entry, index, ratings) => {
       const previousRaterEntry = ratings[index - 1];
       const previousPlace = previousRaterEntry ? previousRaterEntry[4] : 0;

--- a/utils/formatRatingData.js
+++ b/utils/formatRatingData.js
@@ -51,12 +51,10 @@ module.exports = values => {
      * @NOTE Can't use the short hand here since we're dealing with
      * negative integers
      */
-    .sort((firstArray, secondArray) => {
-      if (firstArray[1] > secondArray[1]) {
-        return 0;
-      }
-      return 1;
-    })
+    .sort(
+      (firstArray, secondArray) =>
+        (parseInt(secondArray[1], 10) - parseInt(firstArray[1], 10)),
+    )
     .map((entry, index, ratings) => {
       const previousRatingEntry = ratings[index - 1];
       const previousPlace = previousRatingEntry ? previousRatingEntry[4] : 0;


### PR DESCRIPTION
This PR applies a small fix to the rating value and rating count values to properly sort entries with negative rating values.

This was due to an improper use of the `sort()` callback in the `formatRaterData` util